### PR TITLE
Support TypeScript 5 and 6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,26 +1,26 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "multipart-stream",
       "devDependencies": {
         "@types/bun": "latest",
+        "typescript": "^6.0.2",
       },
       "peerDependencies": {
-        "typescript": "^5.0.0",
+        "typescript": "^5.0.0 || ^6.0.0",
       },
     },
   },
   "packages": {
-    "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/node": ["@types/node@22.13.0", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA=="],
 
-    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
-    "bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
-
-    "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
   }

--- a/lib/part.ts
+++ b/lib/part.ts
@@ -89,7 +89,7 @@ export class Part implements AsyncIterable<Uint8Array> {
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/bytes)
    */
   async bytes(): Promise<Uint8Array> {
-    return await new Blob(await Array.fromAsync(this)).bytes();
+    return await new Blob(await Array.fromAsync(this) as BlobPart[]).bytes();
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sv2dev/multipart-stream",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A utility to process multipart/form-data and multipart/mixed bodies.",
   "repository": {
     "type": "git",
@@ -21,9 +21,10 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "typescript": "^6.0.2"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0 || ^6.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,6 @@
     "noPropertyAccessFromIndexSignature": false,
     "outDir": "dist"
   },
-  "include": ["./index.ts", "./lib/**/*.ts"]
+  "include": ["./index.ts", "./lib/**/*.ts"],
+  "exclude": ["./lib/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary

- Allow both TypeScript 5 and 6 in peerDependencies
- Pin TypeScript 6.0.2 as dev dependency for local development
- Bump to version 0.2.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version bump (0.2.2 → 0.2.3)
  * Added TypeScript 6.0.2 as a development dependency
  * Expanded peer dependency constraints to support both TypeScript 5 and 6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->